### PR TITLE
Implement Iterable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ pubspec.lock
 packages
 .idea
 *.iml
+.packages

--- a/lib/option.dart
+++ b/lib/option.dart
@@ -2,6 +2,7 @@ library option;
 
 import 'package:concepts/concepts.dart';
 import 'package:either/either.dart';
+import 'dart:collection';
 
 part 'src/option.dart';
 part 'src/some.dart';

--- a/lib/src/none.dart
+++ b/lib/src/none.dart
@@ -1,6 +1,6 @@
 part of option;
 
-class None<T> implements Option<T> {
+class None<T> extends IterableBase<T> implements Option<T> {
 
   /**
    * The const constructor for the None<T> type.
@@ -77,4 +77,6 @@ class None<T> implements Option<T> {
    */
   String toString() => "None";
 
+  @override
+  Iterator<T> get iterator => new Iterable<T>.empty().iterator;
 }

--- a/lib/src/option.dart
+++ b/lib/src/option.dart
@@ -3,7 +3,8 @@ part of option;
 abstract class Option<T>
 implements Functor<Option>,
            Applicative<Option>,
-           Monad<Option>
+           Monad<Option>,
+           Iterable<T>
 {
 
   /**

--- a/lib/src/some.dart
+++ b/lib/src/some.dart
@@ -1,6 +1,6 @@
 part of option;
 
-class Some<T> implements Option<T> {
+class Some<T> extends IterableBase<T> implements Option<T> {
 
   final T _inner;
 
@@ -88,4 +88,6 @@ class Some<T> implements Option<T> {
    */
   String toString() => "Some($_inner)";
 
+  @override
+  Iterator<T> get iterator => <T>[_inner].iterator;
 }

--- a/test/option_test.dart
+++ b/test/option_test.dart
@@ -18,6 +18,11 @@ optionTests() {
       );
     });
 
+    test('Interoperates with iterables', () {
+      final optionals = <Option<int>>[new Some<int>(1), const None(), new Some<int>(2)]
+        .expand((i) => i);
+      expect(optionals, orderedEquals([1, 2]));
+    });
   });
 }
 
@@ -180,7 +185,6 @@ someTests() {
 }
 
 main() {
-
   optionTests();
   noneTests();
   someTests();

--- a/test/option_test.dart
+++ b/test/option_test.dart
@@ -88,6 +88,10 @@ noneTests() {
       expect(instance.toString(), equals("None"));
     });
 
+    test('length should return 0', () {
+      expect(instance.length, equals(0));
+    });
+
   });
 }
 
@@ -166,6 +170,10 @@ someTests() {
 
     test("toString() should return Some(3)", () {
       expect(instance.toString(), "Some(3)");
+    });
+
+    test('length should return 1', () {
+      expect(instance.length, equals(1));
     });
 
   });


### PR DESCRIPTION
Implementing `Iterable` allows an `Option` to be passed into anything expecting an `Iterable` and facilitates common cases like

```
final optionals = <Option<int>>[new Some<int>(1), const None(), new Some<int>(2)];
final ints = optionals.expand((i) => i); // (1, 2)
```